### PR TITLE
可以配置需要处理依赖关系的文件扩展名

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -122,6 +122,9 @@ var createHanlder = module.exports = function (res, options) {
     // 模板目录
     var views = options.views;
 
+    // 需要处理依赖关系的文件扩展名
+    var depthExt = options.depthExt || ['css', 'js'];
+
     var loaded = [];
 
     // include all async files
@@ -170,7 +173,7 @@ var createHanlder = module.exports = function (res, options) {
             }
             added[depId] = true;
             var dep = fis.getInfo(depId, true);
-            if (!dep || (dep.type !== 'js' && dep.type !== 'css')) {
+            if (!dep || (depthExt.indexOf(dep.type) < 0)) {
                 return;
             }
             depList = depList.concat(getDepList(dep, added));
@@ -197,7 +200,7 @@ var createHanlder = module.exports = function (res, options) {
             }
             depScaned[depId] = true;
             var dep = fis.getInfo(depId, true);
-            if (!dep || (dep.type !== 'js' && dep.type !== 'css')) {
+            if (!dep || depthExt.indexOf(dep.type) < 0) {
                 return;
             }
             asyncList = asyncList.concat(getAsyncList(dep, added, depScaned));
@@ -208,7 +211,7 @@ var createHanlder = module.exports = function (res, options) {
             }
             added[asyncId] = true;
             var async = fis.getInfo(asyncId, true);
-            if (!async || (async.type !== 'js' && async.type !== 'css')) {
+            if (!async || (depthExt.indexOf(async.type) < 0)) {
                 return;
             }
             asyncList = asyncList.concat(getAsyncList(async, added, depScaned));
@@ -237,7 +240,7 @@ var createHanlder = module.exports = function (res, options) {
                 var depList = getDepList(file, addedSync);
                 var asyncList = getAsyncList(file, addedAsync, depScaned);
                 syncs = syncs.concat(depList);
-                if (file.type === 'js' || file.type === 'css') {
+                if ( (depthExt.indexOf(syncs.type) >= 0)) {
                     syncs.push(file);
                 }
                 asyncs = asyncs.concat(asyncList);


### PR DESCRIPTION
发现layer层读取map-json处理文件依赖时，只会处理css与js文件，但是模板tmpl文件之间的依赖没有处理。希望可以动态配置需要处理的文件扩展名。