### PR TITLE
Update layer.js

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -65,7 +65,7 @@ function afterPageletRender(pagelet, locals) {
 function hasEventLinstener(emiter, type, fn) {
     var list = emiter._events[type];
 
-    if (list && (list === fn || ~list.indexOf(fn))) {
+    if (list && (list === fn || (list.indexOf && ~list.indexOf(fn)))) {
         return true;
     }
 


### PR DESCRIPTION
事件list如果是个fn的时候，没有indexOf方法会报错，使用indexOf之前先判断下是不是数组；

复现步骤：

```js
//这样事件会报错
res.bigpipe.on('pagelet:render:before', ()=>{})
```